### PR TITLE
fix: Object.hashAll() generation for fields.length > 20

### DIFF
--- a/packages/theme_extensions_builder/lib/src/generator/code_generator.dart
+++ b/packages/theme_extensions_builder/lib/src/generator/code_generator.dart
@@ -314,9 +314,13 @@ Method hashMethod(GeneratorConfig config) {
     case _:
       body.addExpression(
         refer('Object').property('hashAll').call([
-          refer('runtimeType'),
-          for (final field in fields.values)
-            refer('value').property(field.name),
+          literalList(
+            [
+              refer('runtimeType'),
+              for (final field in fields.values)
+                refer('value').property(field.name),
+            ],
+          ),
         ]).returned,
       );
   }

--- a/packages/theme_extensions_builder/lib/src/generator/code_generator.dart
+++ b/packages/theme_extensions_builder/lib/src/generator/code_generator.dart
@@ -303,7 +303,7 @@ Method hashMethod(GeneratorConfig config) {
       body.addExpression(
         refer('runtimeType').property('hashCode').returned,
       );
-    case <= 20:
+    case <= 19:
       body.addExpression(
         refer('Object').property('hash').call([
           refer('runtimeType'),
@@ -314,13 +314,11 @@ Method hashMethod(GeneratorConfig config) {
     case _:
       body.addExpression(
         refer('Object').property('hashAll').call([
-          literalList(
-            [
-              refer('runtimeType'),
-              for (final field in fields.values)
-                refer('value').property(field.name),
-            ],
-          ),
+          literalList([
+            refer('runtimeType'),
+            for (final field in fields.values)
+              refer('value').property(field.name),
+          ]),
         ]).returned,
       );
   }


### PR DESCRIPTION
colors.g.theme.dart:193:26: Error: Too many positional arguments: 1 allowed, but 36 found.
    return Object.hashAll()
    
// was (30+ fields):
return Object.hashAll(a, b, c, d, /* ... */);

// should be:
return Object.hashAll([
  a, b, c, d, /* ... others ... */
]);